### PR TITLE
feat(custom message): support start and end custom message

### DIFF
--- a/src/main/java/jenkins/plugins/bearychat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/bearychat/ActiveNotifier.java
@@ -50,7 +50,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         return notifier.newBearychatService(r, listener);
     }
 
-    public Map<String, Object> getData(AbstractBuild build){
+    public Map<String, Object> getData(AbstractBuild build) {
         JenkinsLocationConfiguration globalConfig = new JenkinsLocationConfiguration();
         String configUrl = notifier.getBuildServerUrl();
 
@@ -89,9 +89,12 @@ public class ActiveNotifier implements FineGrainedNotifier {
         jobMap.put("duration", duration);
         jobMap.put("commit_message", commitMessage);
 
-        if(notifier.includeBearychatCustomMessage()){
+        if(notifier.includeBearychatCustomMessage()) {
             String customMessage = getCustomMessage(build);
             jobMap.put("custom_message", customMessage);
+
+            String customEndMessage = getCustomEndMessage(build);
+            jobMap.put("custom_end_message", customEndMessage);
         }
 
 
@@ -110,7 +113,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         Set<String> authors = new HashSet<String>();
         for (Entry entry : entries) {
             String displayName = entry.getAuthor().getDisplayName();
-            if(!"".equals(nonsense)){
+            if(!"".equals(nonsense)) {
                 authors.add(displayName);
             }
         }
@@ -127,7 +130,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         return result;
     }
 
-    public String getCustomMessage(AbstractBuild build){
+    public String getCustomMessage(AbstractBuild build) {
          String customMessage = notifier.getBearychatCustomMessage();
          EnvVars envVars = new EnvVars();
          try {
@@ -139,6 +142,20 @@ public class ActiveNotifier implements FineGrainedNotifier {
              logger.log(SEVERE, e.getMessage(), e);
          }
          return customMessage;
+    }
+
+    public String getCustomEndMessage(AbstractBuild build) {
+        String customEndMessage = notifier.getBearychatEndCustomMessage();
+        EnvVars envVars = new EnvVars();
+        try {
+            envVars = build.getEnvironment(new LogTaskListener(logger, INFO));
+            customEndMessage = envVars.expand(customEndMessage);
+        } catch (IOException e) {
+            logger.log(SEVERE, e.getMessage(), e);
+        } catch (InterruptedException e) {
+            logger.log(SEVERE, e.getMessage(), e);
+        }
+        return customEndMessage;
     }
 
     String getChanges(AbstractBuild r) {
@@ -206,7 +223,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
             commit.append(" [").append(entry.getAuthor().getDisplayName()).append("]");
             commits.append("- ").append(commit.toString()).append("\n");
         }
-        if(entries.size() > 5){
+        if(entries.size() > 5) {
             int left = entries.size() - 5;
             commits.append(left).append(" more...");
         }
@@ -235,7 +252,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         message.appendDuration();
         message.appendOpenLink();
 
-        if(notifier.includeBearychatCustomMessage()){
+        if(notifier.includeBearychatCustomMessage()) {
             message.appendCustomMessage();
         }
 
@@ -262,7 +279,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         String color = "green";
         Run previousBuild = build.getProject().getLastBuild().getPreviousBuild();
         Result lastResult = previousBuild == null ? null : previousBuild.getResult();
-        if(lastResult != null && lastResult == Result.FAILURE){
+        if(lastResult != null && lastResult == Result.FAILURE) {
             color = "red";
         }
 
@@ -424,7 +441,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         public MessageBuilder appendDuration() {
             message.append(" after ");
             String durationString;
-            if(message.toString().contains(BACK_TO_NORMAL_STATUS_MESSAGE)){
+            if(message.toString().contains(BACK_TO_NORMAL_STATUS_MESSAGE)) {
                 durationString = createBackToNormalDurationString();
             } else {
                 durationString = build.getDurationString();
@@ -448,7 +465,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
             return this;
         }
 
-        private String createBackToNormalDurationString(){
+        private String createBackToNormalDurationString() {
             Run previousSuccessfulBuild = build.getPreviousSuccessfulBuild();
             long previousSuccessStartTime = previousSuccessfulBuild.getStartTimeInMillis();
             long previousSuccessDuration = previousSuccessfulBuild.getDuration();

--- a/src/main/java/jenkins/plugins/bearychat/BearychatNotifier.java
+++ b/src/main/java/jenkins/plugins/bearychat/BearychatNotifier.java
@@ -42,6 +42,7 @@ public class BearychatNotifier extends Notifier {
     private boolean notifyRepeatedFailure;
     private boolean includeBearychatCustomMessage;
     private String bearychatCustomMessage;
+    private String bearychatEndCustomMessage;
 
     @Override
     public DescriptorImpl getDescriptor() {
@@ -109,11 +110,15 @@ public class BearychatNotifier extends Notifier {
         return bearychatCustomMessage;
     }
 
+    public String getBearychatEndCustomMessage() {
+        return bearychatEndCustomMessage;
+    }
+
     @DataBoundConstructor
     public BearychatNotifier(final String teamDomain, final String authToken, final String room, final String buildServerUrl,
                              final String sendAs, final boolean startNotification, final boolean notifyAborted, final boolean notifyFailure,
                              final boolean notifyNotBuilt, final boolean notifySuccess, final boolean notifyUnstable, final boolean notifyBackToNormal,
-                             boolean includeBearychatCustomMessage, String bearychatCustomMessage) {
+                             boolean includeBearychatCustomMessage, String bearychatCustomMessage, String bearychatEndCustomMessage) {
         super();
         this.teamDomain = teamDomain;
         this.authToken = authToken;
@@ -129,6 +134,7 @@ public class BearychatNotifier extends Notifier {
         this.notifyBackToNormal = notifyBackToNormal;
         this.includeBearychatCustomMessage = includeBearychatCustomMessage;
         this.bearychatCustomMessage = bearychatCustomMessage;
+        this.bearychatEndCustomMessage = bearychatEndCustomMessage;
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
@@ -239,8 +245,10 @@ public class BearychatNotifier extends Notifier {
             boolean notifyBackToNormal = "true".equals(sr.getParameter("bearychatNotifyBackToNormal"));
             boolean includeBearychatCustomMessage = "on".equals(sr.getParameter("includeBearychatCustomMessage"));
             String bearychatCustomMessage = sr.getParameter("bearychatCustomMessage");
+            String bearychatEndCustomMessage = sr.getParameter("bearychatEndCustomMessage");
             return new BearychatNotifier(teamDomain, token, room, buildServerUrl, sendAs, startNotification, notifyAborted,
-                    notifyFailure, notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal, includeBearychatCustomMessage, bearychatCustomMessage);
+                    notifyFailure, notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal,
+                    includeBearychatCustomMessage, bearychatCustomMessage, bearychatEndCustomMessage);
         }
 
         @Override

--- a/src/main/resources/jenkins/plugins/bearychat/BearychatNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/bearychat/BearychatNotifier/config.jelly
@@ -30,8 +30,11 @@
 
     <f:advanced>
         <f:optionalBlock name="includeBearychatCustomMessage" title="Custom Message" checked="${instance.includeBearychatCustomMessage()}">
-            <f:entry title="" help="${rootURL}/plugin/bearychat/help-projectConfig-bearychatCustomMessage.html">
+            <f:entry title="Start" help="${rootURL}/plugin/bearychat/help-projectConfig-bearychatCustomMessage.html">
                 <f:textarea name="bearychatCustomMessage" value="${instance.getBearychatCustomMessage()}"/>
+            </f:entry>
+            <f:entry title="End" help="${rootURL}/plugin/bearychat/help-projectConfig-bearychatEndCustomMessage.html">
+                 <f:textarea name="bearychatEndCustomMessage" value="${instance.getBearychatEndCustomMessage()}"/>
             </f:entry>
         </f:optionalBlock>
 

--- a/src/main/webapp/help-projectConfig-bearychatCustomMessage.html
+++ b/src/main/webapp/help-projectConfig-bearychatCustomMessage.html
@@ -1,5 +1,6 @@
 <div>
   <p>
-    Enter a custom message that will be included with the notifications. Include build variables in the form <a href="https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-JenkinsSetEnvironmentVariables">Jenkins Environment Variables</a> by putting <em>$VAR_NAME</em> where you want it to appear.
+     Custom Message will be included at jenkins START process.
+     Include build variables in the form <a href="https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-JenkinsSetEnvironmentVariables">Jenkins Environment Variables</a> by putting <em>$VAR_NAME</em> where you want it to appear.
   </p>
 </div>

--- a/src/main/webapp/help-projectConfig-bearychatEndCustomMessage.html
+++ b/src/main/webapp/help-projectConfig-bearychatEndCustomMessage.html
@@ -1,0 +1,6 @@
+<div>
+  <p>
+    Custom Message will be included at jenkins END process, no matter success, failure or abort.
+    Include build variables in the form <a href="https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-JenkinsSetEnvironmentVariables">Jenkins Environment Variables</a> by putting <em>$VAR_NAME</em> where you want it to appear.
+  </p>
+</div>


### PR DESCRIPTION
支持插件 custom message 在开始和结束时，都可以指定内容，还需要 jenkins bearychat 支持 custom_end_messag 新变量。为了兼容的目的，老的变量没用改名字。效果如图：

![image](https://cloud.githubusercontent.com/assets/4557527/23165286/4c6894be-f876-11e6-81c6-c89e8c40918c.png)
