### PR TITLE
fix(config): update jenkins upload plugin for publish failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580</version>
+    <version>2.2</version>
   </parent>
 
   <artifactId>bearychat</artifactId>


### PR DESCRIPTION
发布失败,消息大致为:
INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.6:deploy (default-deploy) on project claim: Failed to deploy artifacts: Could not transfer artifact org.jenkins-ci.plugins:claim:hpi:2.9 from/to maven.jenkins-ci.org (http://maven.jenkins-ci.org:8081/content/repositories/releases): Connect to maven.jenkins-ci.org:8081 [maven.jenkins-ci.org/199.193.196.24] failed: Operation timed out -> [Help 1]

解决方案:
https://groups.google.com/forum/#!topic/jenkinsci-dev/_uyZUatliYg

